### PR TITLE
remove redundant code

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "mocha": "^3.0.1",
     "plist": "^1.2.0",
     "run-sequence": "^1.2.2",
-    "tinycolor2": "^1.4.1",
-    "uuid": "^2.0.2"
+    "tinycolor2": "^1.4.1"
   },
   "scripts": {
     "style": "npm run style:main",

--- a/prefs/icon_R.tmPreferences
+++ b/prefs/icon_R.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.r</string>
+<dict>
+    <key>scope</key><string>source.r</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_R</string>
+        <key>icon</key><string>file_type_R</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_actionscript.tmPreferences
+++ b/prefs/icon_actionscript.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.actionscript</string>
+<dict>
+    <key>scope</key><string>source.actionscript</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_actionscript</string>
+        <key>icon</key><string>file_type_actionscript</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_angular.tmPreferences
+++ b/prefs/icon_angular.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>text.html.basic.angularjs</string>
+<dict>
+    <key>scope</key><string>text.html.basic.angularjs</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_angular</string>
+        <key>icon</key><string>file_type_angular</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_apache.tmPreferences
+++ b/prefs/icon_apache.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.apacheconf, source.hive</string>
+<dict>
+    <key>scope</key><string>source.apacheconf, source.hive</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_apache</string>
+        <key>icon</key><string>file_type_apache</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_applescript.tmPreferences
+++ b/prefs/icon_applescript.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.applescript, source.applescript-scpt</string>
+<dict>
+    <key>scope</key><string>source.applescript, source.applescript-scpt</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_applescript</string>
+        <key>icon</key><string>file_type_applescript</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_blade.tmPreferences
+++ b/prefs/icon_blade.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>text.blade, text.html.laravel-blade</string>
+<dict>
+    <key>scope</key><string>text.blade, text.html.laravel-blade</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_blade</string>
+        <key>icon</key><string>file_type_blade</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_bower.tmPreferences
+++ b/prefs/icon_bower.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.json.bower</string>
+<dict>
+    <key>scope</key><string>source.json.bower</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_bower</string>
+        <key>icon</key><string>file_type_bower</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_c#.tmPreferences
+++ b/prefs/icon_c#.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.cs</string>
+<dict>
+    <key>scope</key><string>source.cs</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_c#</string>
+        <key>icon</key><string>file_type_c#</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_c++.tmPreferences
+++ b/prefs/icon_c++.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.c++, source.cuda-c++, source.objc++</string>
+<dict>
+    <key>scope</key><string>source.c++, source.cuda-c++, source.objc++</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_c++</string>
+        <key>icon</key><string>file_type_c++</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_c.tmPreferences
+++ b/prefs/icon_c.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.c</string>
+<dict>
+    <key>scope</key><string>source.c</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_c</string>
+        <key>icon</key><string>file_type_c</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_cfc.tmPreferences
+++ b/prefs/icon_cfc.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.cfscript.cfc</string>
+<dict>
+    <key>scope</key><string>source.cfscript.cfc</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_cfc</string>
+        <key>icon</key><string>file_type_cfc</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_cfm.tmPreferences
+++ b/prefs/icon_cfm.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.cfml, text.html.cfm</string>
+<dict>
+    <key>scope</key><string>source.cfml, text.html.cfm</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_cfm</string>
+        <key>icon</key><string>file_type_cfm</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_clojure.tmPreferences
+++ b/prefs/icon_clojure.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.clojure</string>
+<dict>
+    <key>scope</key><string>source.clojure</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_clojure</string>
+        <key>icon</key><string>file_type_clojure</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_coffee.tmPreferences
+++ b/prefs/icon_coffee.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.coffee, source.litcoffee, source.pegcs</string>
+<dict>
+    <key>scope</key><string>source.coffee, source.litcoffee, source.pegcs</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_coffeescript</string>
+        <key>icon</key><string>file_type_coffeescript</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_css.tmPreferences
+++ b/prefs/icon_css.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.css, source.postcss</string>
+<dict>
+    <key>scope</key><string>source.css, source.postcss</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_css</string>
+        <key>icon</key><string>file_type_css</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_dlang.tmPreferences
+++ b/prefs/icon_dlang.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.d</string>
+<dict>
+    <key>scope</key><string>source.d</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_dlang</string>
+        <key>icon</key><string>file_type_dlang</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_dockerfile.tmPreferences
+++ b/prefs/icon_dockerfile.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.dockerfile</string>
+<dict>
+    <key>scope</key><string>source.dockerfile</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_docker</string>
+        <key>icon</key><string>file_type_docker</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_erlang.tmPreferences
+++ b/prefs/icon_erlang.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.erlang</string>
+<dict>
+    <key>scope</key><string>source.erlang</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_erlang</string>
+        <key>icon</key><string>file_type_erlang</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_ex.tmPreferences
+++ b/prefs/icon_ex.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.elixir</string>
+<dict>
+    <key>scope</key><string>source.elixir</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_ex</string>
+        <key>icon</key><string>file_type_ex</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_fish.tmPreferences
+++ b/prefs/icon_fish.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.fish</string>
+<dict>
+    <key>scope</key><string>source.fish</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_fish</string>
+        <key>icon</key><string>file_type_fish</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_font.tmPreferences
+++ b/prefs/icon_font.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>font</string>
+<dict>
+    <key>scope</key><string>font</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_font</string>
+        <key>icon</key><string>file_type_font</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_git.tmPreferences
+++ b/prefs/icon_git.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.git, source.gitconfig, source.gitignore, text.git-blame, text.git-commit, text.git-commit-message, text.git-commit-view, text.git-graph, text.git.commit-message, text.git.config, text.git.rebase</string>
+<dict>
+    <key>scope</key><string>source.git, source.gitconfig, source.gitignore, text.git-blame, text.git-commit, text.git-commit-message, text.git-commit-view, text.git-graph, text.git.commit-message, text.git.config, text.git.rebase</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_git</string>
+        <key>icon</key><string>file_type_git</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_go.tmPreferences
+++ b/prefs/icon_go.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.go</string>
+<dict>
+    <key>scope</key><string>source.go</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_go</string>
+        <key>icon</key><string>file_type_go</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_gradle.tmPreferences
+++ b/prefs/icon_gradle.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.gradle</string>
+<dict>
+    <key>scope</key><string>source.gradle</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_gradle</string>
+        <key>icon</key><string>file_type_gradle</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_graphviz.tmPreferences
+++ b/prefs/icon_graphviz.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.dot, source.gv</string>
+<dict>
+    <key>scope</key><string>source.dot, source.gv</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_graphviz</string>
+        <key>icon</key><string>file_type_graphviz</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_groovy.tmPreferences
+++ b/prefs/icon_groovy.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.groovy</string>
+<dict>
+    <key>scope</key><string>source.groovy</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_groovy</string>
+        <key>icon</key><string>file_type_groovy</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_gruntfile.tmPreferences
+++ b/prefs/icon_gruntfile.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.gruntfile</string>
+<dict>
+    <key>scope</key><string>source.gruntfile</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_gruntfile</string>
+        <key>icon</key><string>file_type_gruntfile</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_gulpfile.tmPreferences
+++ b/prefs/icon_gulpfile.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.coffee.gulpfile, source.gulp_results, source.gulpfile.js, source.js.gulpfile</string>
+<dict>
+    <key>scope</key><string>source.coffee.gulpfile, source.gulp_results, source.gulpfile.js, source.js.gulpfile</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_gulpfile</string>
+        <key>icon</key><string>file_type_gulpfile</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_haml.tmPreferences
+++ b/prefs/icon_haml.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.haml, source.hamlbars, source.php.haml, text.haml, text.hamlpy</string>
+<dict>
+    <key>scope</key><string>source.haml, source.hamlbars, source.php.haml, text.haml, text.hamlpy</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_haml</string>
+        <key>icon</key><string>file_type_haml</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_haskell.tmPreferences
+++ b/prefs/icon_haskell.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.haskell</string>
+<dict>
+    <key>scope</key><string>source.haskell</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_haskell</string>
+        <key>icon</key><string>file_type_haskell</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_haxe.tmPreferences
+++ b/prefs/icon_haxe.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.haxe</string>
+<dict>
+    <key>scope</key><string>source.haxe</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_haxe</string>
+        <key>icon</key><string>file_type_haxe</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_html.tmPreferences
+++ b/prefs/icon_html.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>text.html.basic, text.html.eco, text.html.elixir, text.html.jstl, text.html.rt</string>
+<dict>
+    <key>scope</key><string>text.html.basic, text.html.eco, text.html.elixir, text.html.jstl, text.html.rt</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_html</string>
+        <key>icon</key><string>file_type_html</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_jade.tmPreferences
+++ b/prefs/icon_jade.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.jade, source.pyjade, text.jade</string>
+<dict>
+    <key>scope</key><string>source.jade, source.pyjade, text.jade</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_jade</string>
+        <key>icon</key><string>file_type_jade</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_java.tmPreferences
+++ b/prefs/icon_java.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.java</string>
+<dict>
+    <key>scope</key><string>source.java</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_java</string>
+        <key>icon</key><string>file_type_java</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_js.tmPreferences
+++ b/prefs/icon_js.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.js, source.pegjs</string>
+<dict>
+    <key>scope</key><string>source.js, source.pegjs</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_js</string>
+        <key>icon</key><string>file_type_js</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_json.tmPreferences
+++ b/prefs/icon_json.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.json</string>
+<dict>
+    <key>scope</key><string>source.json</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_settings</string>
+        <key>icon</key><string>file_type_settings</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_jsp.tmPreferences
+++ b/prefs/icon_jsp.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>text.html.jsp</string>
+<dict>
+    <key>scope</key><string>text.html.jsp</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_jsp</string>
+        <key>icon</key><string>file_type_jsp</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_julia.tmPreferences
+++ b/prefs/icon_julia.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.jl, source.julia</string>
+<dict>
+    <key>scope</key><string>source.jl, source.julia</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_julia</string>
+        <key>icon</key><string>file_type_julia</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_less.tmPreferences
+++ b/prefs/icon_less.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.less</string>
+<dict>
+    <key>scope</key><string>source.less</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_less</string>
+        <key>icon</key><string>file_type_less</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_license.tmPreferences
+++ b/prefs/icon_license.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>license</string>
+<dict>
+    <key>scope</key><string>license</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_license</string>
+        <key>icon</key><string>file_type_license</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_liquid.tmPreferences
+++ b/prefs/icon_liquid.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>text.html.liquid</string>
+<dict>
+    <key>scope</key><string>text.html.liquid</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_liquid</string>
+        <key>icon</key><string>file_type_liquid</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_lisp.tmPreferences
+++ b/prefs/icon_lisp.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.lisp</string>
+<dict>
+    <key>scope</key><string>source.lisp</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_lisp</string>
+        <key>icon</key><string>file_type_lisp</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_lsl.tmPreferences
+++ b/prefs/icon_lsl.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.lsl</string>
+<dict>
+    <key>scope</key><string>source.lsl</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_lsl</string>
+        <key>icon</key><string>file_type_lsl</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_lua.tmPreferences
+++ b/prefs/icon_lua.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.lua</string>
+<dict>
+    <key>scope</key><string>source.lua</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_lua</string>
+        <key>icon</key><string>file_type_lua</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_markdown.tmPreferences
+++ b/prefs/icon_markdown.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>text.html.markdown, text.html.markdown.multimarkdown</string>
+<dict>
+    <key>scope</key><string>text.html.markdown, text.html.markdown.multimarkdown</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_markdown</string>
+        <key>icon</key><string>file_type_markdown</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_matlab.tmPreferences
+++ b/prefs/icon_matlab.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.matlab</string>
+<dict>
+    <key>scope</key><string>source.matlab</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_matlab</string>
+        <key>icon</key><string>file_type_matlab</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_mustache.tmPreferences
+++ b/prefs/icon_mustache.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.handlebars, source.mustache, text.html.handlebars, text.html.hgn, text.html.mustache, txt.html.mustache</string>
+<dict>
+    <key>scope</key><string>source.handlebars, source.mustache, text.html.handlebars, text.html.hgn, text.html.mustache, txt.html.mustache</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_mustache</string>
+        <key>icon</key><string>file_type_mustache</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_npm.tmPreferences
+++ b/prefs/icon_npm.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.json.npm</string>
+<dict>
+    <key>scope</key><string>source.json.npm</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_npm</string>
+        <key>icon</key><string>file_type_npm</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_ocaml.tmPreferences
+++ b/prefs/icon_ocaml.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.camlp4.ocaml, source.ocaml, source.ocamllex, source.ocamlyacc</string>
+<dict>
+    <key>scope</key><string>source.camlp4.ocaml, source.ocaml, source.ocamllex, source.ocamlyacc</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_ocaml</string>
+        <key>icon</key><string>file_type_ocaml</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_perl.tmPreferences
+++ b/prefs/icon_perl.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.perl</string>
+<dict>
+    <key>scope</key><string>source.perl</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_perl</string>
+        <key>icon</key><string>file_type_perl</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_php.tmPreferences
+++ b/prefs/icon_php.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>embedding.php, source.php</string>
+<dict>
+    <key>scope</key><string>embedding.php, source.php</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_php</string>
+        <key>icon</key><string>file_type_php</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_postscript.tmPreferences
+++ b/prefs/icon_postscript.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.ps</string>
+<dict>
+    <key>scope</key><string>source.ps</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_postscript</string>
+        <key>icon</key><string>file_type_postscript</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_powershell.tmPreferences
+++ b/prefs/icon_powershell.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.powershell</string>
+<dict>
+    <key>scope</key><string>source.powershell</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_powershell</string>
+        <key>icon</key><string>file_type_powershell</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_procfile.tmPreferences
+++ b/prefs/icon_procfile.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.procfile</string>
+<dict>
+    <key>scope</key><string>source.procfile</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_procfile</string>
+        <key>icon</key><string>file_type_procfile</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_puppet.tmPreferences
+++ b/prefs/icon_puppet.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.puppet</string>
+<dict>
+    <key>scope</key><string>source.puppet</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_puppet</string>
+        <key>icon</key><string>file_type_puppet</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_python.tmPreferences
+++ b/prefs/icon_python.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.python</string>
+<dict>
+    <key>scope</key><string>source.python</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_python</string>
+        <key>icon</key><string>file_type_python</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_rails.tmPreferences
+++ b/prefs/icon_rails.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>text.html.ruby</string>
+<dict>
+    <key>scope</key><string>text.html.ruby</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_rails</string>
+        <key>icon</key><string>file_type_rails</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_react.tmPreferences
+++ b/prefs/icon_react.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.js.jsx, source.jsx, source.tsx</string>
+<dict>
+    <key>scope</key><string>source.js.jsx, source.jsx, source.tsx</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_react</string>
+        <key>icon</key><string>file_type_react</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_ruby.tmPreferences
+++ b/prefs/icon_ruby.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.ruby</string>
+<dict>
+    <key>scope</key><string>source.ruby</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_ruby</string>
+        <key>icon</key><string>file_type_ruby</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_rust.tmPreferences
+++ b/prefs/icon_rust.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.rust</string>
+<dict>
+    <key>scope</key><string>source.rust</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_rust</string>
+        <key>icon</key><string>file_type_rust</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_sass.tmPreferences
+++ b/prefs/icon_sass.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.sass</string>
+<dict>
+    <key>scope</key><string>source.sass</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_sass</string>
+        <key>icon</key><string>file_type_sass</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_scala.tmPreferences
+++ b/prefs/icon_scala.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.scala</string>
+<dict>
+    <key>scope</key><string>source.scala</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_scala</string>
+        <key>icon</key><string>file_type_scala</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_scss.tmPreferences
+++ b/prefs/icon_scss.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.scss</string>
+<dict>
+    <key>scope</key><string>source.scss</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_scss</string>
+        <key>icon</key><string>file_type_scss</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_shell.tmPreferences
+++ b/prefs/icon_shell.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.dosbatch, source.shell</string>
+<dict>
+    <key>scope</key><string>source.dosbatch, source.shell</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_shell</string>
+        <key>icon</key><string>file_type_shell</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_slim.tmPreferences
+++ b/prefs/icon_slim.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>text.slim</string>
+<dict>
+    <key>scope</key><string>text.slim</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_slim</string>
+        <key>icon</key><string>file_type_slim</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_sql.tmPreferences
+++ b/prefs/icon_sql.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.pgsql, source.simple-db-migrate, source.sql</string>
+<dict>
+    <key>scope</key><string>source.pgsql, source.simple-db-migrate, source.sql</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_sql</string>
+        <key>icon</key><string>file_type_sql</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_stata.tmPreferences
+++ b/prefs/icon_stata.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <key>scope</key>
-    <string>source.ado, source.do, source.stata</string>
+    <key>scope</key><string>source.ado, source.do, source.stata</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_stata</string>
+        <key>icon</key><string>file_type_stata</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_stylus.tmPreferences
+++ b/prefs/icon_stylus.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.styl, source.stylus</string>
+<dict>
+    <key>scope</key><string>source.styl, source.stylus</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_stylus</string>
+        <key>icon</key><string>file_type_stylus</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_swift.tmPreferences
+++ b/prefs/icon_swift.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.swift</string>
+<dict>
+    <key>scope</key><string>source.swift</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_swift</string>
+        <key>icon</key><string>file_type_swift</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_tcl.tmPreferences
+++ b/prefs/icon_tcl.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.tcl, text.html.tcl</string>
+<dict>
+    <key>scope</key><string>source.tcl, text.html.tcl</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_tcl</string>
+        <key>icon</key><string>file_type_tcl</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_tex.tmPreferences
+++ b/prefs/icon_tex.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>text.bibtex, text.log.latex, text.tex</string>
+<dict>
+    <key>scope</key><string>text.bibtex, text.log.latex, text.tex</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_tex</string>
+        <key>icon</key><string>file_type_tex</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_textile.tmPreferences
+++ b/prefs/icon_textile.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>text.html.textile</string>
+<dict>
+    <key>scope</key><string>text.html.textile</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_textile</string>
+        <key>icon</key><string>file_type_textile</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_twig.tmPreferences
+++ b/prefs/icon_twig.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>text.html.twig</string>
+<dict>
+    <key>scope</key><string>text.html.twig</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_twig</string>
+        <key>icon</key><string>file_type_twig</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_typescript.tmPreferences
+++ b/prefs/icon_typescript.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.ts</string>
+<dict>
+    <key>scope</key><string>source.ts</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_typescript</string>
+        <key>icon</key><string>file_type_typescript</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_vue.tmPreferences
+++ b/prefs/icon_vue.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>text.html.vue</string>
+<dict>
+    <key>scope</key><string>text.html.vue</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_vue</string>
+        <key>icon</key><string>file_type_vue</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/prefs/icon_yaml.tmPreferences
+++ b/prefs/icon_yaml.tmPreferences
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>scope</key>
-    <string>source.yaml</string>
+<dict>
+    <key>scope</key><string>source.yaml</string>
     <key>settings</key>
     <dict>
-      <key>icon</key>
-      <string>file_type_yaml</string>
+        <key>icon</key><string>file_type_yaml</string>
     </dict>
-  </dict>
+</dict>
 </plist>

--- a/src/scheme.js
+++ b/src/scheme.js
@@ -1,8 +1,6 @@
 module.exports = function (values) {
   'use strict';
 
-  const uuid = require('uuid');
-
   const c = values.colors;
   const info = values.info;
 
@@ -1525,6 +1523,5 @@ module.exports = function (values) {
       },
 
     ],
-    uuid: uuid.v4(),
   };
 };


### PR DESCRIPTION
* removed addition of generated uuids as ST ignores those anyway (unless they are know and you want to target a file by uuid or whatever)
  * `src/scheme.js`
  * `package.json`
* removed headers from metadata as ST ignores those, too
  * I would have removed them from schemes and themes, but that would've required post-processing and I wasn't sure that's worth the hassle.

---

FYI: didn't run the build process, only touched source files.