### PR TITLE
Added command to activate theme using command palette

### DIFF
--- a/commands/Default.sublime-commands
+++ b/commands/Default.sublime-commands
@@ -1,4 +1,9 @@
 [
+    
+    {
+        "caption": "gruvbox: Select Theme",
+        "command": "gruvbox_select"
+    },
     {
         "caption": "gruvbox: Readme",
         "command": "gruvbox_readme"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4,3 +4,5 @@
 
 from .documentation import *
 from .support import *
+from .gruvbox import *
+

--- a/src/gruvbox.py
+++ b/src/gruvbox.py
@@ -1,0 +1,62 @@
+import math
+import sublime
+import sublime_plugin
+
+class GruvboxSelect(sublime_plugin.TextCommand):
+    def run(self, action):
+        color_schemes = sublime.find_resources("gruvbox*.tmTheme")
+        color_themes = sublime.find_resources("gruvbox*.sublime-theme")
+
+        temp_schemes = []
+        self.themes = []
+        self.schemes = []
+
+        for scheme in color_schemes:
+            if 'Packages/gruvbox/' in scheme:
+                temp_schemes.append(scheme[17:-8])
+
+        for i in range(len(temp_schemes)):
+            if (i % 2) == 0:
+                self.schemes.insert(i + 1, temp_schemes[i])
+            else:
+                self.schemes.insert(i - 1, temp_schemes[i])
+
+        for theme in color_themes:
+            if 'Packages/gruvbox/' in theme:
+                self.themes.append(theme[17:])
+
+        self.show_panel()
+
+    def show_panel(self):
+        self.view.window().show_quick_panel(self.schemes, self.on_done, on_highlight=self.on_highlighted)
+
+    def on_done(self, index):
+        self.set_scheme('Packages/gruvbox/' + self.schemes[index] + '.tmTheme')
+        self.set_theme(self.themes[self.find_index(index)])
+        self.save_settings(self.schemes[index])
+
+    def on_highlighted(self, index):
+        self.set_scheme('Packages/gruvbox/' + self.schemes[index] + '.tmTheme')
+        self.set_theme(self.themes[self.find_index(index)])
+
+    def find_index(self, index):
+        if index == 0 or index == 1:
+            return 0
+        else:
+            return int(math.floor((index / 2)))
+
+    def set_scheme(self, scheme):
+        self.get_settings().set('color_scheme', scheme)
+
+    def set_theme(self, theme):
+        self.get_settings().set('theme', theme)
+
+    def get_settings(self):
+        return sublime.load_settings('Preferences.sublime-settings')
+
+    def save_settings(self, theme):
+        sublime.save_settings('Preferences.sublime-settings')
+        sublime.status_message('gruvbox: ' + theme)
+        print('')
+        print('[gruvbox] ' +  theme)
+        print('')


### PR DESCRIPTION
This enables users to select and activate gruvbox themes as follows:

Step 1:
![image](https://user-images.githubusercontent.com/32819562/31618297-361c2ee8-b2af-11e7-9902-915ccea90432.png)

Step 2:
![image](https://user-images.githubusercontent.com/32819562/31618301-3a8451a4-b2af-11e7-9d46-aaf8c38c7ffb.png)

Step 3:
![image](https://user-images.githubusercontent.com/32819562/31618314-3f720b84-b2af-11e7-9c4f-9da5ab330734.png)
